### PR TITLE
Set up dependabot to raise PRs automatically for security vulnerabilities

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0 # set to 0 so only security updates are raised


### PR DESCRIPTION
Why?
- To not have to manually trigger the PR updates.